### PR TITLE
standalone docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,50 @@
+FROM    ubuntu:16.04
+
+ENV     DEBIAN_FRONTEND noninteractive
+ARG	GITREPO=https://github.com/imaginationforpeople/assembl.git
+ARG	GITBRANCH=develop
+
+RUN     apt-get update && apt-get install -y \
+            fabric \
+            git \
+            openssh-server \
+            pandoc \
+            sudo \
+            net-tools \
+            monit \
+            nginx \
+            uwsgi \
+            uwsgi-plugin-python
+RUN     ssh-keygen -P '' -f ~/.ssh/id_rsa && \
+            cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
+RUN     cd /opt ; set -x ; git clone -b $GITBRANCH $GITREPO
+WORKDIR /opt/assembl
+RUN     /etc/init.d/ssh start && \
+           ssh-keyscan localhost && \
+           cp production.ini local.ini && \
+           fab devenv install_builddeps && \
+           cp docker/nginx_config_docker/default /etc/nginx/sites-enabled/ && \
+           /etc/init.d/ssh stop
+RUN     /etc/init.d/ssh start && \
+           ssh-keyscan localhost && \
+           /etc/init.d/postgresql start && \
+           /etc/init.d/redis-server start && \
+           chgrp www-data -R var && \
+           chmod g=u -R var && \
+           fab devenv bootstrap_from_checkout && \
+           . venv/bin/activate && \
+           assembl-add-user --email root@localhost --name "Admin" --username admin --password admin local.ini && \
+           supervisorctl shutdown && \
+           /etc/init.d/postgresql stop && \
+           /etc/init.d/redis-server stop && \
+           /etc/init.d/ssh stop
+EXPOSE 80
+CMD     /etc/init.d/ssh start && \
+        /etc/init.d/redis-server start && \
+        /etc/init.d/memcached start && \
+        /etc/init.d/postgresql start && \
+        /etc/init.d/nginx start && \
+        . venv/bin/activate && \
+        supervisord && \
+        supervisorctl start prod: && \
+        tail -f /dev/null

--- a/fabfile.py
+++ b/fabfile.py
@@ -1341,8 +1341,8 @@ def commonenv(projectpath, venvpath=None):
     env.vbranch = get_config().get('virtuoso', 'virtuoso_branch')
     
     env.dbdumps_dir = join(projectpath, '%s_dumps' % env.projectname)
-    env.gitrepo = "https://github.com/ImaginationForPeople/assembl.git"
-    env.gitbranch = "master"
+    env.gitrepo = getenv("GITREPO", "https://github.com/ImaginationForPeople/assembl.git")
+    env.gitbranch = getenv("GITBRANCH", "master")
 
     env.uses_memcache = True
     env.uses_uwsgi = False
@@ -1426,7 +1426,7 @@ def env_dev(projectpath=None):
     env.uses_apache = False
     env.uses_ngnix = False
 
-    env.gitbranch = "develop"
+    env.gitbranch = getenv("GITBRANCH", "develop")
 
 
 @task
@@ -1447,8 +1447,7 @@ def env_testing(projectpath=None):
     env.uses_apache = False
     env.uses_ngnix = False
 
-    env.gitbranch = "develop"
-
+    env.gitbranch = getenv("GITBRANCH", "develop")
 
 @task
 def env_coeus_assembl():
@@ -1469,7 +1468,7 @@ def env_coeus_assembl():
     env.uses_apache = False
     env.uses_ngnix = True
     env.uses_uwsgi = True
-    env.gitbranch = "master"
+    env.gitbranch = getenv("GITBRANCH", "master")
 
 
 @task
@@ -1491,7 +1490,7 @@ def env_coeus_assembl2():
     env.uses_apache = False
     env.uses_ngnix = True
     env.uses_uwsgi = True
-    env.gitbranch = "develop"
+    env.gitbranch = getenv("GITBRANCH", "develop")
 
 
 @task
@@ -1514,7 +1513,7 @@ def env_inm_agora():
     env.uses_apache = False
     env.uses_ngnix = True
     env.uses_uwsgi = True
-    env.gitbranch = "master"
+    env.gitbranch = getenv("GITBRANCH", "master")
 
 
 @task
@@ -1536,7 +1535,7 @@ def env_bluenove_discussions():
     env.uses_apache = False
     env.uses_ngnix = True
     env.uses_uwsgi = True
-    env.gitbranch = "master"
+    env.gitbranch = getenv("GITBRANCH", "master")
 
 @task
 def env_bluenove_assembl2():
@@ -1557,7 +1556,7 @@ def env_bluenove_assembl2():
     env.uses_apache = False
     env.uses_ngnix = True
     env.uses_uwsgi = True
-    env.gitbranch = "master"
+    env.gitbranch = getenv("GITBRANCH", "master")
 
 @task
 def env_paris_debat():
@@ -1578,7 +1577,7 @@ def env_paris_debat():
     env.uses_apache = False
     env.uses_ngnix = True
     env.uses_uwsgi = True
-    env.gitbranch = "master"
+    env.gitbranch = getenv("GITBRANCH", "master")
 
 
 @task
@@ -1600,4 +1599,4 @@ def env_thecampfactory():
     env.uses_apache = False
     env.uses_ngnix = True
     env.uses_uwsgi = True
-    env.gitbranch = "master"
+    env.gitbranch = getenv("GITBRANCH", "master")


### PR DESCRIPTION
For test purposes it is convenient to have an all-in-one docker image, including redis, memcached and the database server. So that it can be run with:

    docker run --port 8000:80 --v /opt/assembl:/var/lib/database assembl
    firefox localhost:8000

